### PR TITLE
(deps) Update nova-packages-tool version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.0",
         "laravel/nova": "^4.0|^5.0",
-        "nova-kit/nova-packages-tool": "^1.3|v2.0"
+        "nova-kit/nova-packages-tool": "^1.3|^v2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Changed the version constraint for nova-kit/nova-packages-tool from '^1.3|v2.0' to '^1.3|^v2.0' in composer.json to allow for more flexible version matching.